### PR TITLE
 Externalise metadata editor associated resources panel configuration

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
@@ -602,7 +602,7 @@ public class MetadataSchema {
     }
 
     public void setDependsOn(String depends) {
-        this.dependsOn = dependsOn;
+        this.dependsOn = depends;
     }
 
     public Map<String, String> getTitles() {

--- a/services/src/main/java/org/fao/geonet/api/standards/StandardsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/standards/StandardsApi.java
@@ -314,7 +314,7 @@ public class StandardsApi implements ApplicationContextAware {
 
     @ApiOperation(value = "Get editor associated resources panel configuration",
         nickname = "getEditorAssociatedPanelConfiguration")
-    @RequestMapping(value = "/{schema}/editor/associatedpanel/config/default.json",
+    @RequestMapping(value = "/{schema}/editor/associatedpanel/config/{name:[a-zA-Z]+}.json",
         method = RequestMethod.GET,
         produces = {
             MediaType.APPLICATION_JSON_VALUE
@@ -324,7 +324,12 @@ public class StandardsApi implements ApplicationContextAware {
         @ApiParam(value = "Schema identifier",
             required = true,
             example = "iso19139")
-        @PathVariable String schema
+        @PathVariable String schema,
+        @ApiParam(value = "Configuration identifier",
+            required = true,
+            defaultValue = "default",
+            example = "default")
+        @PathVariable String name
     ) throws Exception {
 
         String schemaToCheck = schema;
@@ -343,7 +348,7 @@ public class StandardsApi implements ApplicationContextAware {
 
             Path configFile = schemaDir.resolve("config").
                 resolve("associated-panel").
-                resolve("default.json");
+                resolve(name + ".json");
 
             if (Files.exists(configFile)) {
                 String jsonConfig = new String(Files.readAllBytes(configFile));
@@ -360,8 +365,8 @@ public class StandardsApi implements ApplicationContextAware {
 
 
         throw new ResourceNotFoundException(String.format(
-            "Associated panel configuration for schema '%s' not found.",
-            schema));
+            "Associated panel configuration '%s' for schema '%s' not found.",
+            name, schema));
 
 
     }

--- a/web-ui/src/main/resources/catalog/components/common/schemamanager/SchemaManagerService.js
+++ b/web-ui/src/main/resources/catalog/components/common/schemamanager/SchemaManagerService.js
@@ -143,21 +143,22 @@
             * Load metadata editor associated panel configuration
             * for a schema.
             */
-           getEditorAssociationPanelConfig: function(schema) {
+           getEditorAssociationPanelConfig: function(schema, config) {
              var defer = $q.defer();
-             var cacheKey = schema + "-associatedpanel";
+             var cacheKey = schema + '-associatedpanel-' + config;
              var fromCache = infoCache.get(cacheKey);
              if (fromCache) {
                defer.resolve(fromCache);
              } else {
                $http.get('../api/standards/' + schema +
-                 '/editor/associatedpanel/config/default.json',
+                 '/editor/associatedpanel/config/' +
+                 (config || 'default') + '.json',
                  { cache: false }).
                then(function(response) {
                  infoCache.put(cacheKey, response.data);
-                 defer.resolve(response);
+                 defer.resolve(response.data);
                }, function(response) {
-                 defer.reject(response);
+                 defer.reject(response.data);
                });
              }
              return defer.promise;

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -209,6 +209,7 @@
               scope.allowEdits = true;
               scope.lang = scope.$parent.lang;
               scope.readonly = attrs['readonly'] || false;
+              scope.gnCurrentEdit.associatedPanelConfigId = attrs['configId'] || 'default';
               scope.relations = {};
 
               /**
@@ -589,13 +590,27 @@
                       initMultilingualFields();
                     }
                   };
+                  function loadConfigAndInit(withInit) {
+                    gnSchemaManagerService.getEditorAssociationPanelConfig(
+                      gnCurrentEdit.schema,
+                      gnCurrentEdit.associatedPanelConfigId).then(function (r) {
+                      scope.config = r.config;
 
-                  gnSchemaManagerService.getEditorAssociationPanelConfig(gnCurrentEdit.schema).
-                  then(function(response) {
-                    scope.config = response.data.config;
+                      if (withInit) {
+                        init();
+                      }
+                    });
+                  };
 
-                    init();
+                  scope.$watch('gnCurrentEdit.associatedPanelConfigId',
+                    function(n, o) {
+                      if (n && n !== o) {
+                        loadConfigAndInit(false);
+                      }
                   });
+
+                  loadConfigAndInit(true);
+
                 });
 
                 // mode can be 'url' or 'thumbnailMaker' to init thumbnail panel

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -231,6 +231,7 @@
                   id: $routeParams.id,
                   formId: '#gn-editor-' + $routeParams.id,
                   containerId: '#gn-editor-container-' + $routeParams.id,
+                  associatedPanelConfigId: 'default',
                   tab: $location.search()['tab'] || defaultTab,
                   displayAttributes: $location.search()['displayAttributes'] === 'true',
                   displayTooltips: $location.search()['displayTooltips'] === 'true',


### PR DESCRIPTION
 Use the following to customize the config for a view:
    ```
            <directive data-gn-onlinesrc-list=""
                       data-config-id="dummy"
                       data-types="onlinesrc|parent|dataset|service|source|sibling|associated|fcats"/>
    ```
    
Also fix:
* cache retrieval was not returning same object
* add possibility to have multiple config and load them using the API
* handle depends on 