### PR TITLE
LESS / Avoid loading bootstrap twice

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -1,25 +1,8 @@
-@import "gn_bootstrap.less";
+@import "gn.less";
 
 @import "../lib/bootstrap.ext/tagsinput/bootstrap-tagsinput.less";
 // import the css files as less files so they are included in the final output of wro4j
 @import (less) "../lib/jquery.ext/jquery.fileupload-ui.css";
-@import "gn.less";
-
-@import "../lib/style/bootstrap/less/glyphicons.less";
-
-//url is wrong on original file
-// Import the fonts
-@font-face {
-  font-family: "Glyphicons Halflings";
-  src: ~"url('../catalog/lib/style/bootstrap/fonts/@{icon-font-name}.eot')";
-  src: ~"url('../catalog/lib/style/bootstrap/fonts/@{icon-font-name}.eot?#iefix') format('embedded-opentype')",
-    ~"url('../catalog/lib/style/bootstrap/fonts/@{icon-font-name}.woff') format('woff')",
-    ~"url('../catalog/lib/style/bootstrap/fonts/@{icon-font-name}.ttf') format('truetype')",
-    ~"url('../catalog/lib/style/bootstrap/fonts/@{icon-font-name}.svg#@{icon-font-svg-id}') format('svg')";
-}
-
-body {
-}
 
 .gn-line-height {
   line-height: 1.8 !important;


### PR DESCRIPTION
even if it looks like LESS compilation is taking care of duplicated rules. Also remove glyphicons which I don't think we use. Was added for calendar https://github.com/geonetwork/core-geonetwork/commit/88462d83f12c5ae2f6dce79657bfc768bc836029 but we are using browser date/time inputs in the editor so probably uneeded.