### PR TITLE
Validation / INSPIRE / Display error message on error

### DIFF
--- a/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
@@ -143,7 +143,7 @@
                     });
                   } else {
                     gnAlertService.addAlert({
-                      msg: error.data.description,
+                      msg: error.data.message || error.data.description,
                       type: "danger"
                     });
                   }


### PR DESCRIPTION
I was getting empty feedback when using INSPIRE official validator returning 403

![Pasted image](https://github.com/GeoCat/core-geonetwork/assets/1701393/6b162bef-cd2b-4ba1-8bae-71068a60846b)


Tested other case with invalid URL and error is reported. Batch validation is not reporting info but that's another topic.