### PR TITLE
Test / Fix bean initialization

### DIFF
--- a/core/src/test/resources/core-repository-test-context.xml
+++ b/core/src/test/resources/core-repository-test-context.xml
@@ -141,4 +141,9 @@
 
   <bean id="servletContext" class="org.fao.geonet.GeonetMockServletContext"/>
   <bean id="threadPool" class="org.fao.geonet.TestThreadPool"/>
+  
+  <bean class="org.fao.geonet.analytics.WebAnalyticsConfiguration" name="webAnalyticsConfiguration">
+    <property name="service" value="" />
+    <property name="javascriptCode" value="" />
+  </bean>
 </beans>


### PR DESCRIPTION
Failing test were:

```
15:47:17,320 [INFO] Results:
15:47:17,320 [INFO] 
Error: 7,320 [ERROR] Failures: 
Error: 7,320 [ERROR]   AlternateLogoForPdfExportTest.whenGeneratingPdfWithPropertyNotSetSiteLogoIsUsed:114 Status expected:<200> but was:<400>
Error: 7,321 [ERROR]   AlternateLogoForPdfExportTest.whenGeneratingPdfWithPropertySetPdfLogoIsUsed:74 Status expected:<200> but was:<400>
Error: 7,321 [ERROR]   AlternateLogoForPdfExportTest.whenNotGeneratingPdfWithPropertySetSiteLogoIsUsed:93 Status expected:<200> but was:<400>
Error: 7,321 [ERROR] Errors: 
Error: 7,321 [ERROR]   FormatterApiIntegrationTest.testExec:97 » XPath Exception in extension functio.
```


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
