### PR TITLE
Search / Sort by / Fix multiple fields

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
@@ -203,6 +203,7 @@
           params.sort = [];
           sortBy.split(",", -1).forEach(function (value, idx) {
             if (value != "relevance") {
+              var sort = {};
               sort[getFieldName(mappingFields, value)] = orders[idx] || "asc";
               params.sort.push(sort);
             }

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -187,6 +187,7 @@
     "sortBy-dateStampDesc": "last updates",
     "sortBy-createDateDesc": "new records",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
+    "sortBy-resourceTitleObject.${searchLang}.keyword": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",
     "sortBy-relevance": "relevancy",
     "sortBy-ratingDesc": "rating",


### PR DESCRIPTION
eg. `resourceTitleObject.${searchLang}.keyword,resourceTitleObject.default.keyword`

should create a filter

```
[
    {
        "resourceTitleObject.langdut.keyword": "asc"
    },
    {
        "resourceTitleObject.default.keyword": "asc"
    },
    "_score"
]
```


add translation for the default example provided `resourceTitleObject.${searchLang}.keyword`

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

