### PR TITLE
Proxy / Make distinction between methods.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -895,7 +895,7 @@
             };
 
             var loadFunction = function (imageTile, src) {
-              $http.head(src, { nointercept: true }).then(
+              $http.head(src).then(
                 function (r) {
                   imageTile.getImage().src = src;
                 },
@@ -1660,7 +1660,7 @@
                     var _url = url.split("/");
                     _url = _url[0] + "/" + _url[1] + "/" + _url[2] + "/";
                     if (
-                      $.inArray(_url, gnGlobalSettings.requireProxy) >= 0 &&
+                      $.inArray(_url + "#GET", gnGlobalSettings.requireProxy) >= 0 &&
                       url.indexOf(gnGlobalSettings.proxyUrl) != 0
                     ) {
                       capL.useProxy = true;

--- a/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
+++ b/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
@@ -81,10 +81,15 @@
                 if (mapservice !== null) {
                   if (mapservice.useProxy) {
                     // If we need to use the proxy then add it to requireProxy list.
-                    if ($.inArray(config.url, gnGlobalSettings.requireProxy) === -1) {
+                    if (
+                      $.inArray(
+                        config.url + "#" + config.method,
+                        gnGlobalSettings.requireProxy
+                      ) === -1
+                    ) {
                       var url = config.url.split("/");
                       url = url[0] + "/" + url[1] + "/" + url[2] + "/";
-                      gnGlobalSettings.requireProxy.push(url);
+                      gnGlobalSettings.requireProxy.push(url + "#" + config.method);
                     }
                   } else {
                     // If we are not using a proxy then add the headers.
@@ -113,7 +118,10 @@
                 var url = config.url.split("/");
                 url = url[0] + "/" + url[1] + "/" + url[2] + "/";
 
-                if ($.inArray(url, gnGlobalSettings.requireProxy) !== -1) {
+                if (
+                  $.inArray(url + "#" + config.method, gnGlobalSettings.requireProxy) !==
+                  -1
+                ) {
                   // require proxy
                   config.url = gnGlobalSettings.proxyUrl + encodeURIComponent(config.url);
                 }
@@ -156,8 +164,13 @@
                     var url = config.url.split("/");
                     url = url[0] + "/" + url[1] + "/" + url[2] + "/";
 
-                    if ($.inArray(url, gnGlobalSettings.requireProxy) === -1) {
-                      gnGlobalSettings.requireProxy.push(url);
+                    if (
+                      $.inArray(
+                        url + "#" + config.method,
+                        gnGlobalSettings.requireProxy
+                      ) === -1
+                    ) {
+                      gnGlobalSettings.requireProxy.push(url + "#" + config.method);
                     }
 
                     $injector.invoke([

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
@@ -87,7 +87,7 @@
               var url = $scope.url.split("/");
               getCapLayer.useProxy = false;
               url = url[0] + "/" + url[1] + "/" + url[2] + "/";
-              if ($.inArray(url, gnGlobalSettings.requireProxy) >= 0) {
+              if ($.inArray(url + "#GET", gnGlobalSettings.requireProxy) >= 0) {
                 getCapLayer.useProxy = true;
               }
               if ($scope.format == "wms") {


### PR DESCRIPTION
Some servers provides CORS header for some method eg. GET and not for other eg. HEAD. In such case, if a failure occurs on a HEAD request, then the proxy is activated for that domain but is not needed for GET request. If user is anonymous, then proxy forbid access to the domain (if the domain is not in the link analysis table with default configuration) and simple action like `GetCapabilities` will fail.

Add the method to the domain as key to know if the proxy has to be used or not.

Can be tested with https://haleconnect.com/ows/services/org.789.b36c0053-db6b-4fe7-9402-4e5d8ac35e06_wms


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

