### PR TITLE
remove es.url and use the components (es.protocol, es.host, es.port) instead

### DIFF
--- a/core/src/test/resources/WEB-INF/config.properties
+++ b/core/src/test/resources/WEB-INF/config.properties
@@ -8,7 +8,7 @@ usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
 usersavedselection.watchlist.recordurl=api/records/{{index:uuid}}
 
 
-es.url=http://localhost:9200
+
 es.port=9200
 es.host=localhost
 es.protocol=http

--- a/docs/manual/docs/install-guide/installing-index.md
+++ b/docs/manual/docs/install-guide/installing-index.md
@@ -113,7 +113,7 @@ By default, GeoNetwork expects Elasticsearch to be running at <http://localhost:
 * Define the connection details in Java properties.
 
   ```shell
-  export JAVA_OPTS="$JAVA_OPTS -Des.protocol=http -Des.port=9200 -Des.host=localhost -Des.url=http://localhost:9200 -Des.username= -Des.password="
+  export JAVA_OPTS="$JAVA_OPTS -Des.protocol=http -Des.port=9200 -Des.host=localhost  -Des.protocol=http -Des.username= -Des.password="
   ```
 
 * Define the connection details in environment variables.
@@ -122,7 +122,6 @@ By default, GeoNetwork expects Elasticsearch to be running at <http://localhost:
   export GEONETWORK_ES_HOST=localhost
   export GEONETWORK_ES_PROTOCOL=http
   export GEONETWORK_ES_PORT=9200
-  export GEONETWORK_ES_URL=$GEONETWORK_ES_PROTOCOL://$GEONETWORK_ES_HOST:$GEONETWORK_ES_PORT
   export GEONETWORK_ES_USERNAME=
   export GEONETWORK_ES_PASSWORD=
   ```
@@ -133,7 +132,6 @@ By default, GeoNetwork expects Elasticsearch to be running at <http://localhost:
   es.protocol=#{systemEnvironment['GEONETWORK_ES_PROTOCOL']?:'http'}
   es.port=#{systemEnvironment['GEONETWORK_ES_PORT']?:9200}
   es.host=#{systemEnvironment['GEONETWORK_ES_HOST']?:'localhost'}
-  es.url=#{systemEnvironment['GEONETWORK_ES_URL']?:'http://localhost:9200'}
   es.username=#{systemEnvironment['GEONETWORK_ES_USERNAME']?:''}
   es.password=#{systemEnvironment['GEONETWORK_ES_PASSWORD']?:''}
   ```

--- a/docs/manual/docs/tutorials/introduction/deployment/deploy.md
+++ b/docs/manual/docs/tutorials/introduction/deployment/deploy.md
@@ -30,7 +30,9 @@ Once you have Tomcat installed on your system, locate the webapps folder and pla
 Open the file /geonetwork/WEB-INF/config.properties and alter the elasticsearch connection
 
 ``` bash
-$ es.url=http://localhost:9200
+es.protocol=http
+es.host=localhost
+es.port=9200
 ```
 
 Then (re)start Jetty/Tomcat.

--- a/harvesters/src/test/resources/WEB-INF/config.properties
+++ b/harvesters/src/test/resources/WEB-INF/config.properties
@@ -7,7 +7,6 @@ usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
 # Define the link to each record sent by email by the watchlist notifier
 usersavedselection.watchlist.recordurl=api/records/{{index:uuid}}
 
-es.url=http://localhost:9200
 es.port=9200
 es.host=localhost
 es.protocol=http

--- a/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
+++ b/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
@@ -82,7 +82,7 @@ public class EsRestClient implements InitializingBean {
 
     private ElasticsearchAsyncClient asyncClient;
 
-    @Value("${es.url}")
+
     private String serverUrl;
 
     @Value("${es.protocol}")
@@ -128,10 +128,18 @@ public class EsRestClient implements InitializingBean {
 
     @Override
     public void afterPropertiesSet() throws Exception {
+        if (StringUtils.isBlank(serverProtocol) || StringUtils.isBlank(serverHost) || StringUtils.isBlank(serverPort)) {
+            Log.error("geonetwork.index", String.format(
+                "Elasticsearch URL defined by serverProtocol='%s', serverHost='%s', serverPort='%s' is missing. "
+                    + "Check configuration.", this.serverProtocol,this.serverHost,this.serverPort));
+        }
+
+        //build server URL
+        serverUrl = serverProtocol + "://" + serverHost + ":" + serverPort;
         if (StringUtils.isNotEmpty(serverUrl)) {
             RestClientBuilder builder = RestClient.builder(new HttpHost(serverHost, Integer.parseInt(serverPort), serverProtocol));
 
-            if (serverUrl.startsWith("https://")) {
+            if (serverProtocol.startsWith("https")) {
                 SSLContext sslContext = new SSLContextBuilder().loadTrustMaterial(
                     null, new TrustStrategy() {
                         public boolean isTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {

--- a/pom.xml
+++ b/pom.xml
@@ -1598,7 +1598,6 @@
     <es.protocol>http</es.protocol>
     <es.port>9200</es.port>
     <es.host>localhost</es.host>
-    <es.url>${es.protocol}://${es.host}:${es.port}</es.url>
     <es.index.features>gn-features</es.index.features>
     <es.index.features.type>features</es.index.features.type>
     <es.index.records>gn-records</es.index.records>

--- a/schemas-test/src/main/webapp/WEB-INF/config.properties
+++ b/schemas-test/src/main/webapp/WEB-INF/config.properties
@@ -7,8 +7,9 @@ usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
 # Define the link to each record sent by email by the watchlist notifier
 usersavedselection.watchlist.recordurl=api/records/{{index:uuid}}
 
-
-es.url=http://localhost:9200
+es.protocol=http
+es.host=localhost
+es.port=9200
 es.index.features=features
 es.index.records=records
 es.index.searchlogs=searchlogs

--- a/services/src/main/webapp/WEB-INF/config.properties
+++ b/services/src/main/webapp/WEB-INF/config.properties
@@ -7,8 +7,9 @@ usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
 # Define the link to each record sent by email by the watchlist notifier
 usersavedselection.watchlist.recordurl=api/records/{{index:uuid}}
 
+es.protocol=http
+es.host=localhost
 es.port=9200
-es.url=http://localhost:9200
 es.index.features=features
 es.index.records=records
 es.index.searchlogs=searchlogs

--- a/services/src/test/resources/WEB-INF/config.properties
+++ b/services/src/test/resources/WEB-INF/config.properties
@@ -7,8 +7,7 @@ usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
 # Define the link to each record sent by email by the watchlist notifier
 usersavedselection.watchlist.recordurl=api/records/{{index:uuid}}
 
-es.url=http://localhost:9200
-es.port=9200
+ es.port=9200
 es.host=localhost
 es.protocol=http
 es.index.features=features

--- a/web/src/main/webResources/WEB-INF/config.properties
+++ b/web/src/main/webResources/WEB-INF/config.properties
@@ -14,7 +14,6 @@ usersavedselection.watchlist.recordurl=api/records/{{index:uuid}}
 es.protocol=#{systemEnvironment['GEONETWORK_ES_PROTOCOL']?:'${es.protocol}'}
 es.port=#{systemEnvironment['GEONETWORK_ES_PORT']?:${es.port}}
 es.host=#{systemEnvironment['GEONETWORK_ES_HOST']?:'${es.host}'}
-es.url=#{systemEnvironment['GEONETWORK_ES_URL']?:'${es.url}'}
 es.username=#{systemEnvironment['GEONETWORK_ES_USERNAME']?:'${es.username}'}
 es.password=#{systemEnvironment['GEONETWORK_ES_PASSWORD']?:'${es.password}'}
 es.index.features=${es.index.features}

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -473,7 +473,7 @@
     <servlet-class>org.fao.geonet.proxy.URITemplateProxyServlet</servlet-class>
     <init-param>
       <param-name>targetUri</param-name>
-      <param-value>${es.url}/${es.index.features}/{_}</param-value>
+      <param-value>${es.protocol}://${es.host}:${es.post}/${es.index.features}/{_}</param-value>
     </init-param>
     <init-param>
       <param-name>log</param-name>


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
I've noticed some inconsistencies in the es configuration.

By this I mean;

1. If I set es.host (vi the EnvVars), then it doesn't really really get used. It will be replaced with es.url - which will be localhost (defined earlier).
    * the EsRestClient partially used es.url and partially es.* vars.
    * `RestClientBuilder builder = RestClient.builder(new HttpHost(serverHost, Integer.parseInt(serverPort), serverProtocol));`
    * this is using the defined es.port, es.host, etc.. NOT THE es.url
2. the next line `if (serverUrl.startsWith("https://"))` -- this is using es.url INSTEAD of es.protocol

So, you must:

a. define all the `es.*` variables
b. have `es.url` consistent with the set variables.


This PR removes the `es.url` configuration and instead builds it directly from `es.protocol`, `es.host`,  and `es.port`.  Currently, `es.url` isn't really being used (`EsRestClient` uses the component **not** `es.url`).  I've kept the `serverUrl` variable because its used in a few other places.

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

 
