### PR TITLE
Allow Editor and Reviewer profiles to transfer record ownership

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -1255,6 +1255,38 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware {
             serviceContext, String.valueOf(metadata.getId()))) {
             report.addNotEditableMetadataId(metadata.getId());
         } else {
+            UserSession callerSession = ApiUtils.getUserSession(session);
+            Profile callerProfile = callerSession.getProfile();
+
+            if (callerProfile == Profile.Editor || callerProfile == Profile.Reviewer) {
+                int callerUserId = callerSession.getUserIdAsInt();
+                Integer sourceUsr = metadata.getSourceInfo().getOwner();
+                Integer sourceGrp = metadata.getSourceInfo().getGroupOwner();
+
+                if (callerProfile == Profile.Editor) {
+                    if (!Objects.equals(sourceUsr, callerUserId)) {
+                        report.addNotEditableMetadataId(metadata.getId());
+                        return;
+                    }
+                } else {
+                    Set<Integer> reviewerGroups = accessMan.getReviewerGroups(callerSession);
+                    if (sourceGrp == null || !reviewerGroups.contains(sourceGrp)) {
+                        report.addNotEditableMetadataId(metadata.getId());
+                        return;
+                    }
+                }
+
+                if (!ReservedGroup.isReserved(groupIdentifier)) {
+                    List<Integer> myGroups = userGroupRepository.findGroupIds(
+                        UserGroupSpecs.hasUserId(callerUserId));
+                    if (!myGroups.contains(groupIdentifier)) {
+                        report.addMetadataInfos(metadata,
+                            "Transfer to group " + groupIdentifier + " is not allowed for your profile.");
+                        return;
+                    }
+                }
+            }
+
             // Retrieve the identifiers associated with the metadata uuid.
             // When the workflow is enabled, the metadata can have an approved and a working copy version.
             List<Integer> idList = metadataUtils.findAllIdsBy(MetadataSpecs.hasMetadataUuid(uuid));

--- a/services/src/main/java/org/fao/geonet/api/users/transfer/TransferApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/transfer/TransferApi.java
@@ -186,6 +186,20 @@ public class TransferApi {
                 );
             }
             return list;
+        } else if (myProfile == Profile.Reviewer || myProfile == Profile.Editor) {
+            List<Integer> myGroups = userGroupRepository.findAll(UserGroupSpecs.hasUserId(session.getUserIdAsInt()))
+                .stream().map(ug -> ug.getGroup().getId()).collect(Collectors.toList());
+            List<UserGroup> userGroups = userGroupRepository.findAll(UserGroupSpecs.hasGroupIds(myGroups));
+
+            if (groupTypes != null) {
+                userGroups = userGroups.stream()
+                    .filter(ug -> groupTypes.contains(ug.getGroup().getType()))
+                    .collect(Collectors.toList());
+            }
+            for (UserGroup ug : userGroups) {
+                list.add(new UserGroupsResponse(ug.getUser(), ug.getGroup(), ug.getProfile().name()));
+            }
+            return list;
         } else {
             throw new SecurityException("You don't have rights to do get the groups for this user");
         }

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataSharingApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataSharingApiTest.java
@@ -56,11 +56,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -80,6 +82,9 @@ public class MetadataSharingApiTest extends AbstractServiceIntegrationTest {
 
     private User editorUser;
     private User reviewerUser;
+    private User anotherEditorUser;
+    private User targetUser;
+    private Group foreignGroup;
     private int metadataId;
     private String metadataUuid;
     private ServiceContext context;
@@ -405,11 +410,103 @@ public class MetadataSharingApiTest extends AbstractServiceIntegrationTest {
         _userRepo.save(reviewerUser);
         _userGroupRepo.save(new UserGroup().setGroup(sampleGroup).setProfile(Profile.Reviewer).setUser(reviewerUser));
 
+        anotherEditorUser = UserRepositoryTest.newUser(_inc);
+        anotherEditorUser.setUsername("anothereditor");
+        anotherEditorUser.setProfile(Profile.Editor);
+        _userRepo.save(anotherEditorUser);
+        _userGroupRepo.save(new UserGroup().setGroup(sampleGroup).setProfile(Profile.Editor).setUser(anotherEditorUser));
+
+        targetUser = UserRepositoryTest.newUser(_inc);
+        targetUser.setUsername("targetuser");
+        targetUser.setProfile(Profile.Editor);
+        _userRepo.save(targetUser);
+        _userGroupRepo.save(new UserGroup().setGroup(sampleGroup).setProfile(Profile.Editor).setUser(targetUser));
+
+        foreignGroup = _groupRepo.save(new Group().setName("foreignGroup"));
+
         Metadata metadata = (Metadata) injectMetadataInDb(getSampleMetadataXml(), context, true);
         metadata.getSourceInfo().setOwner(editorUser.getId());
         metadata.getSourceInfo().setGroupOwner(SAMPLE_GROUP_ID);
         metadataRepository.save(metadata);
         metadataId = metadata.getId();
         metadataUuid = metadata.getUuid();
+    }
+
+    @Test
+    public void transferOwnershipAsEditorSucceeds() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAs(editorUser);
+
+        mockMvc.perform(put("/srv/api/records/" + metadataUuid + "/ownership")
+                .session(mockHttpSession)
+                .param("groupIdentifier", String.valueOf(SAMPLE_GROUP_ID))
+                .param("userIdentifier", String.valueOf(targetUser.getId()))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.numberOfRecordsProcessed").value(1))
+            .andExpect(jsonPath("$.numberOfRecordsNotEditable").value(0));
+    }
+
+    @Test
+    public void transferOwnershipAsEditorForNotOwnedRecordFails() throws Exception {
+        // Grant editing permission to SAMPLE_GROUP_ID so that anotherEditorUser passes
+        // canEdit(), but the ownership check in updateOwnership() still blocks the transfer.
+        OperationAllowed editOp = new OperationAllowed();
+        editOp.getId().setMetadataId(metadataId).setGroupId(SAMPLE_GROUP_ID)
+            .setOperationId(ReservedOperation.editing.getId());
+        operationAllowedRepository.save(editOp);
+
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAs(anotherEditorUser);
+
+        mockMvc.perform(put("/srv/api/records/" + metadataUuid + "/ownership")
+                .session(mockHttpSession)
+                .param("groupIdentifier", String.valueOf(SAMPLE_GROUP_ID))
+                .param("userIdentifier", String.valueOf(targetUser.getId()))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.numberOfRecordsNotEditable").value(1));
+    }
+
+    @Test
+    public void transferOwnershipAsEditorToForeignGroupFails() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAs(editorUser);
+
+        mockMvc.perform(put("/srv/api/records/" + metadataUuid + "/ownership")
+                .session(mockHttpSession)
+                .param("groupIdentifier", String.valueOf(foreignGroup.getId()))
+                .param("userIdentifier", String.valueOf(targetUser.getId()))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.numberOfRecordsProcessed").value(0));
+    }
+
+    @Test
+    public void transferOwnershipAsReviewerForGroupRecordSucceeds() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAs(reviewerUser);
+
+        mockMvc.perform(put("/srv/api/records/" + metadataUuid + "/ownership")
+                .session(mockHttpSession)
+                .param("groupIdentifier", String.valueOf(SAMPLE_GROUP_ID))
+                .param("userIdentifier", String.valueOf(targetUser.getId()))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.numberOfRecordsProcessed").value(1));
+    }
+
+    @Test
+    public void retrieveUserGroupsAsEditorReturnsWorkgroupUsers() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAs(editorUser);
+
+        mockMvc.perform(get("/srv/api/users/groups")
+                .session(mockHttpSession)
+                .param("groupTypes", "Workspace")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").isArray())
+            .andExpect(jsonPath("$.length()").value(greaterThan(0)));
     }
 }

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
@@ -154,7 +154,7 @@
       </li>
       <li
         data-ng-show="!excludePattern.test('transferOwnership')"
-        data-ng-if="user.isUserAdminOrMore()"
+        data-ng-if="user.isEditorOrMore()"
       >
         <a
           href=""

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -46,7 +46,7 @@
           <span data-translate="">privileges</span>
         </a>
       </li>
-      <li role="menuitem" data-ng-if="md.isOwned() && user.isUserAdminOrMore()">
+      <li role="menuitem" data-ng-if="md.isOwned() && user.isEditorOrMore()">
         <a
           href=""
           data-ng-click="mdService.openTransferOwnership(md, null, getCatScope())"


### PR DESCRIPTION
## Summary

- **Editor** users can now transfer ownership of records they own to any user within their own groups.
- **Reviewer** users can transfer ownership of records belonging to their groups to any user within their groups.
- The `/users/groups` endpoint now returns group members for Editor and Reviewer profiles (previously restricted to UserAdmin+), which is required to populate the transfer-ownership dialog.
- UI visibility guards in `selection-widget.html` and `mdactionmenu.html` are relaxed from `isUserAdminOrMore()` to `isEditorOrMore()`.

## Test plan

- [ ] Login as an Editor; verify the "Transfer ownership" action appears for owned records.
- [ ] Transfer an owned record to another user in the same group — should succeed.
- [ ] Attempt to transfer a record owned by another user — should be blocked (not editable).
- [ ] Attempt to transfer to a group the Editor does not belong to — should be blocked.
- [ ] Login as a Reviewer; verify the action appears for records in their group.
- [ ] Transfer a group record to another user in the same group — should succeed.
- [ ] Login as a plain Editor and call `GET /srv/api/users/groups` — should return users from their groups.
- [ ] Integration tests (`MetadataSharingApiTest`) pass.