### PR TITLE
Metadata editor / Online resources / Read mimeTypeStrategy from the panel configuration

### DIFF
--- a/docs/manual/docs/user-guide/associating-resources/linking-panel-configuration.md
+++ b/docs/manual/docs/user-guide/associating-resources/linking-panel-configuration.md
@@ -20,7 +20,8 @@ For distribution, configuration has the following properties:
 * `icon` is the icon class.
 * `fileStoreFilter` is a regular expression to filter files available in the metadata store
 * `process` is the XSL process to be applied when the resource is added
-* `fields` defines the fields to populate for the resource and their properties (eg. visible or not, multilingual or not, default value)
+* `fields` defines the fields to populate for the resource and their properties (eg. visible or not, multilingual or not, default value). Some entries are options passed to the
+  process rather than inputs shown to the user, see [MIME type encoding](#mime-type-encoding)
 
 Example:
 
@@ -50,7 +51,43 @@ Example:
       },
 ```
 
+### MIME type encoding
 
+When a distribution type declares a `mimeType` field, the editor shows an input for the resource
+MIME type. `mimeTypeStrategy` controls how the `onlinesrc-add` process encodes it in the record.
+
+With `"mimeTypeStrategy": {"value": "mimeType"}` the protocol element carries the MIME type in a
+`type` attribute, using `gmx:MimeFileType` in ISO19139 and `gcx:MimeFileType` in ISO19115-3:
+
+```xml
+<gmd:protocol>
+  <gmx:MimeFileType type="image/tiff">WWW:DOWNLOAD-1.0-http--download</gmx:MimeFileType>
+</gmd:protocol>
+```
+
+With `"mimeTypeStrategy": {"value": "protocol"}` the MIME type is appended to the protocol,
+separated by a colon:
+
+```xml
+<gmd:protocol>
+  <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download:image/tiff</gco:CharacterString>
+</gmd:protocol>
+```
+
+`mimeTypeStrategy` is an option passed to the process rather than a field the user fills in, so
+it only takes a `value`:
+
+```json
+        "fields": {
+          "url": {"isMultilingual": false},
+          "protocol": {"isMultilingual": false},
+          "mimeType": {"isMultilingual": false},
+          "mimeTypeStrategy": {"value": "mimeType"}
+        }
+```
+
+If `mimeTypeStrategy` is declared without a `value`, `mimeType` is used. If it is not declared at
+all, the process default applies and the MIME type is appended to the protocol.
 
 ## Associated resources
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1184,7 +1184,6 @@
                       url: fields.url,
                       protocol: linkToEdit.protocol,
                       mimeType: linkToEdit.mimeType,
-                      mimeTypeStrategy: "mimeType",
                       name: fields.name,
                       desc: fields.desc,
                       applicationProfile: linkToEdit.applicationProfile,
@@ -1198,7 +1197,6 @@
                     scope.params.linkType = typeConfig;
                     scope.params.protocol = null;
                     scope.params.mimeType = "";
-                    scope.params.mimeTypeStrategy = "mimeType";
                     scope.params.name = "";
                     scope.params.desc = "";
                     initMultilingualFields();
@@ -1383,6 +1381,15 @@
                     processParams[key] = scope.params[key];
                   }
                 });
+
+                // mimeTypeStrategy is a configuration option and not a user input.
+                // Take it from the link type configuration rather than from the form
+                // state, which is reset on protocol change and may be turned into a
+                // multilingual object on a multilingual record.
+                var mimeTypeStrategy = scope.params.linkType.fields.mimeTypeStrategy;
+                if (angular.isDefined(mimeTypeStrategy)) {
+                  processParams.mimeTypeStrategy = mimeTypeStrategy.value || "mimeType";
+                }
 
                 if (scope.isEditing) {
                   processParams.updateKey = scope.editingKey;
@@ -1799,7 +1806,7 @@
                 if (newValue !== oldValue) {
                   scope.config.multilingualFields = [];
                   angular.forEach(newValue.fields, function (f, k) {
-                    if (f.isMultilingual !== false) {
+                    if (scope.isMdMultilingual && f.isMultilingual !== false) {
                       scope.config.multilingualFields.push(k);
                     }
                   });


### PR DESCRIPTION
Follow-up to #9461, targeting that branch so it can be merged in if you agree with the approach.

While reviewing #9461 I ran it on a local 4.4.13-SNAPSHOT catalogue and the behaviour turned out to be the same with and without the patch. The one-line change is correct, `scope.mimeTypeStrategy` really was dead, but the value it assigns is overwritten before the resource is submitted, so `mimeTypeStrategy` still reaches the process empty and the MIME type is dropped.

## What resets it

`openDialog` builds `config.multilingualFields` with an `isMdMultilingual` guard (line 1112), but the `params.linkType` watcher rebuilds the same list without it (line 1800). So on a monolingual record I still saw:

```
multilingualFields: ["mimeTypeStrategy", "name", "desc"]
```

`resetProtocol()` then calls `initMultilingualFields(["name", "desc"])`, which blanks every other entry. That already fires once as the dialog applies the configured default protocol, and again whenever the user picks a protocol. On a multilingual record the value additionally becomes `{eng: "", fre: "", ...}` and is submitted as `eng#|fre#`.

Since `mimeTypeStrategy` is a configuration option and never a user input, this changes it to be read from the link type configuration when the process parameters are built, and removes the two hardcoded assignments. The watcher regains the `isMdMultilingual` guard so it agrees with `openDialog` for any other non-multilingual option field.

## Before

With the configuration from #9461's description, adding a download link with MIME type `image/tiff`:

```
mimeTypeStrategy=
```

```xml
<gmd:protocol>
  <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
</gmd:protocol>
```

`image/tiff` does not appear anywhere in the record. An empty value matches neither `'mimeType'` nor `'protocol'` in `setProtocol`, so the `otherwise` branch writes the bare protocol.

## After

| Config | Path | submitted | stored |
| --- | --- | --- | --- |
| `{"value": "mimeType"}`, monolingual | add | `mimeTypeStrategy=mimeType` | `<gmx:MimeFileType type="image/tiff">` |
| `{"value": "protocol"}`, monolingual | add | `mimeTypeStrategy=protocol` | `WWW:DOWNLOAD-1.0-http--download:image/tiff` |
| `{"value": "mimeType"}`, multilingual record | add | `mimeTypeStrategy=mimeType` | `<gmx:MimeFileType type="image/tiff">` |
| `{"value": "mimeType"}` | edit existing | `mimeTypeStrategy=mimeType` | `<gmx:MimeFileType type="image/tiff">` preserved |
| `{"value": "protocol"}` | edit existing | `mimeTypeStrategy=protocol` | `WWW:DOWNLOAD-1.0-http--download:image/tiff` |

Row 2 is not reachable before this change, since both call sites hardcode `"mimeType"`. In row 3 `params.mimeTypeStrategy` is still the per-language object at submit time, and the same request body carries `name=eng%23...%7CFR%23...` next to a clean `mimeTypeStrategy=mimeType`, so the option is no longer passed through `buildObjectParameter`.

A config no longer needs `"isMultilingual": false` on the field for this to work, so anything already using the snippet from #9461 keeps working.

Tested by hand on an iso19139 record and on the multilingual iso19139 template, checking both the submitted process parameters and the stored XML. `mvn -pl web-ui prettier:check` passes.

## Unrelated thing I noticed

Reaching the configured value on the edit path needs `"default": true` on the `addOnlinesrc` type. `getTypeConfig` (line 964) matches the edited link with `p === (link.protocol || "")` where `p` is the type's `fields.protocol.value`. The iso19139 `addOnlinesrc` type declares `WWW:LINK-1.0-http--link`, so editing a resource with any other protocol matches no type, and without a default type it falls back to `DEFAULT_CONFIG`, discarding the catalogue's tooltips, required flags and `applicationProfile` field along with the strategy.

That is pre-existing and not addressed here. It resolves to `DEFAULT_CONFIG`'s `mimeType`, which is what the current code hardcodes anyway, so there is no regression. Worth a separate look though.
